### PR TITLE
Fix reset action method check

### DIFF
--- a/src/Controller/Admin/UsersController.php
+++ b/src/Controller/Admin/UsersController.php
@@ -190,7 +190,7 @@ class UsersController extends AppController
             return $this->redirect(['action' => 'login']);
         }
 
-        if ($this->request->is(['put'])) {
+        if ($this->request->is(['patch', 'post', 'put'])) {
             $user = $this->Users->patchEntity($user, $this->request->getData());
             if ($this->Users->save($user)) {
                 $this->Flash->success(__d('localized', 'Your password has been reset successfully.'));


### PR DESCRIPTION
## Summary
- allow password reset form to send POST requests

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: vendor not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9007a7a8832e8fd8f4bd0830eaec